### PR TITLE
added code to dump sshkey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# No pem files
+*.pem
+# When creating output with terraform plan/apply
+*.plan

--- a/modules/ticket/main.tf
+++ b/modules/ticket/main.tf
@@ -19,7 +19,7 @@
 
 resource "null_resource" "login_to_ibmcli" {
   provisioner "local-exec" {
-    command = "ibmcloud login -r ${var.datacenter}"
+    command = "ibmcloud login --no-region"
   }
 }
 

--- a/modules/vlans/main.tf
+++ b/modules/vlans/main.tf
@@ -2,6 +2,7 @@ resource "ibm_network_vlan" "public" {
   name       = "${var.datacenter}-public"
   datacenter = var.datacenter
   type       = "PUBLIC"
+  router_hostname = "fcr01a.${var.datacenter}"
   tags       = var.tags
 }
 
@@ -9,6 +10,6 @@ resource "ibm_network_vlan" "private" {
   name       = "${var.datacenter}-private"
   datacenter = var.datacenter
   type       = "PRIVATE"
-  #   router_hostname = "fcr01a.dal06"
+  router_hostname = "bcr01a.${var.datacenter}"
   tags = var.tags
 }


### PR DESCRIPTION
Added router_hostname to ibm_network_vlan module. This was to address a issue with deploying the VSI. This has been tested and is working at this time.

I added a bit of code to dump the ssh key to make it easier for ssh. I updated the gitignore as well.

